### PR TITLE
Added config file option to disable APRS-IS updating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,14 @@ tmp/
 *.tmp
 *.bak
 *.swp
+*.o
 *~.nib
 local.properties
 .classpath
 .settings/
 .loadpath
+
+/picrumbs
 
 # External tool builders
 .externalToolBuilders/

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ PSK_OBJS=psk.o pskgen.o varicode.o
 
 all: picrumbs
 
+install: all
+	/usr/bin/install -D --mode=755 picrumbs /usr/local/bin/picrumbs
+
 picrumbs: $(PC_OBJS)
 	$(C) $(PC_OBJS) -lpthread -lhamlib -lhamlib++ -lwiringPi -lcurl -lgps -o picrumbs
 

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-PiCrumbs, Alpha version 0.2
+PiCrumbs, Alpha version 0.3
 
 DESCRIPTION:
 

--- a/beacon.cpp
+++ b/beacon.cpp
@@ -76,8 +76,9 @@ bool send_pos_report(int path = 0) {			// exactly what it sounds like
 		char pos_lon_dir = 'E';
 		if (pos_lat < 0) pos_lat_dir = 'S';
 		if (pos_lon < 0) pos_lon_dir = 'W';
-		
-		sprintf(pos, "!%02.2f%c%c%03.2f%c%c", abs(pos_lat), pos_lat_dir, symbol_table, abs(pos_lon), pos_lon_dir, symbol_char);
+
+		sprintf(pos, "!%05.2f%c%c%06.2f%c%c", abs(int(pos_lat)*100 + (pos_lat-int(pos_lat))*60) , pos_lat_dir, symbol_table
+						    , abs(int(pos_lon)*100 + (pos_lon-int(pos_lon))*60) , pos_lon_dir, symbol_char);
 	}
 	stringstream buff;
 	buff << pos;

--- a/http.cpp
+++ b/http.cpp
@@ -9,6 +9,7 @@ extern bool tnc_debug;
 extern bool fh_debug;
 
 // LOCAL VARS
+bool aprsis_enable;					// APRS-IS Enable/Disable
 string aprsis_server;					// APRS-IS server name/IP
 unsigned short int aprsis_port;			// APRS-IS port number
 string aprsis_proxy;					// HTTP proxy to use for APRS-IS
@@ -27,6 +28,14 @@ bool send_aprsis_http(const char* source, int source_ssid, const char* destinati
 	stringstream aprsis_url;
 	stringstream buff;
 	string aprsis_postdata;		// we'll build this in a string since stringstream seems to drop newlines
+
+
+	if (aprsis_enable == 0) {
+	    if (tnc_debug || curl_debug) {
+		printf("APRS-IS disabled.  Not sending.\n");
+	    }
+	    return 1;
+	}
 
 	// first, build the TNC2 packet
 	buff << "user " << aprsis_user << " pass " << aprsis_pass << " vers PiCrumbs " << VERSION;

--- a/init.cpp
+++ b/init.cpp
@@ -39,6 +39,7 @@ extern unsigned char gpio_hf_en;				// gpio pin for hf enable
 extern unsigned char gpio_vhf_en;				// gpio pin for vhf enable
 extern string predict_path;					// path to PREDICT program
 extern bool gpio_enable;						// can we use gpio pins
+extern bool aprsis_enable;					// APRS-IS enable
 extern string aprsis_server;					// APRS-IS server name/IP
 extern unsigned short int aprsis_port;			// APRS-IS port number
 extern string aprsis_proxy;					// HTTP proxy to use for APRS-IS
@@ -262,6 +263,7 @@ void init(int argc, char* argv[]) {		// read config, set up serial ports, etc
 	unsigned short int hamlib_model = readconfig.GetInteger("radio", "model", 1);	// dummy rig as default
 	if (hamlib_enable) radio_retune = readconfig.GetBoolean("radio", "retune", "false");	// don't try to retune if hamlib is not enabled
  // aprs-is config
+	aprsis_enable = readconfig.GetBoolean("aprsis", "enable", "false");
 	aprsis_server = readconfig.Get("aprsis", "server", "rotate.aprs2.net");
 	aprsis_port = readconfig.GetInteger("aprsis", "port", 8080);
 	aprsis_proxy = readconfig.Get("aprsis", "proxy", "");

--- a/picrumbs.conf.example
+++ b/picrumbs.conf.example
@@ -77,6 +77,7 @@ path =
 
 ; APRS-IS settings
 [aprsis]
+enable = false
 ; server: name or ip address of an aprs-is server that supports http
 server = rotate.aprs2.net
 ; port: http port of this server, usually 8080.

--- a/version.h
+++ b/version.h
@@ -1,4 +1,4 @@
 #ifndef VERSION
-#define VERSION "0.2"				// program version for messages, etc
+#define VERSION "0.3"				// program version for messages, etc
 #define PACKET_DEST "APMG02"		// packet tocall
 #endif


### PR DESCRIPTION
Wanted this ability since this will be on my R-Pi Zero W in my truck, and I only need it updating via RF.

(may have more changes coming!)